### PR TITLE
Reduce number of requests to check email

### DIFF
--- a/lib/yt/auth.rb
+++ b/lib/yt/auth.rb
@@ -1,3 +1,5 @@
+require 'jwt'
+
 require 'yt/config'
 require 'yt/http_request'
 
@@ -27,8 +29,8 @@ module Yt
 
     # @return [String] the email of an authenticated Google account.
     def email
-      response = HTTPRequest.new(email_params).run
-      response.body['email']
+      decoded_token = JWT.decode tokens['id_token'], nil, false
+      decoded_token[0]['email']
     end
 
   private
@@ -39,13 +41,6 @@ module Yt
         params[:scope] = :email
         params[:redirect_uri] = @redirect_uri
         params[:response_type] = :code
-      end
-    end
-
-    def email_params
-      {}.tap do |params|
-        params[:path] = '/oauth2/v2/userinfo'
-        params[:headers] = {Authorization: "Bearer #{tokens['access_token']}"}
       end
     end
 

--- a/spec/email_spec.rb
+++ b/spec/email_spec.rb
@@ -30,10 +30,8 @@ describe 'Yt::Auth#email' do
     # NOTE: This test needs to be mocked because getting a real authorization
     # code requires a web interaction from a real user.
     before do
-      expect(auth).to receive(:tokens).and_return 'access_token' => '1234'
-      response = double 'response'
-      expect_any_instance_of(Yt::HTTPRequest).to receive(:run) { response }
-      expect(response).to receive(:body).and_return 'email' => email
+      expect(auth).to receive(:tokens).and_return 'id_token' => '1234'
+      expect(JWT).to receive(:decode).and_return [{'email' => email}]
     end
   end
 end

--- a/yt-auth.gemspec
+++ b/yt-auth.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'yt-support', '>= 0.1.1'
+  spec.add_dependency 'jwt', '~> 1.5.6'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rspec', '~> 3.5'


### PR DESCRIPTION
By using `id_token` in the response from Google, account email can be found by JWT decode, without calling another request with access_token