### PR TITLE
Reduce number of requests to check email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.1  - 2017-03-29
+
+* [ENHANCEMENT] Speed up process by fetching email with 1 HTTP request (not 2).
+
 ## 0.2.0  - 2017-03-29
 
 **How to upgrade**

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-Yt::Auth - authenticate users with their Google account
-=======================================================
+Authenticate users with their Google account
+============================================
 
-Yt::Auth helps you write apps that need to authenticate users by means of their Google account.
+Yt::Auth lets you easily authenticate users of your website by means of
+their Google-based email address.
+
+With Yt::Auth, it is easy to limit access to your app to a few users without
+the need for them to create a username and password.
 
 The **source code** is available on [GitHub](https://github.com/fullscreen/yt-auth) and the **documentation** on [RubyDoc](http://www.rubydoc.info/gems/yt-auth/frames).
 
@@ -54,7 +58,6 @@ code = 'this-is-not-a-valid-code'
 Yt::Auth.new(redirect_uri: redirect_uri, code: code).email
  # => Yt::HTTPError: Invalid authorization code.
 ```
-
 
 How to contribute
 =================

--- a/lib/yt/auth.rb
+++ b/lib/yt/auth.rb
@@ -1,3 +1,4 @@
+require 'jwt'
 require 'yt/config'
 require 'yt/http_request'
 
@@ -27,8 +28,7 @@ module Yt
 
     # @return [String] the email of an authenticated Google account.
     def email
-      response = HTTPRequest.new(email_params).run
-      response.body['email']
+      profile['email']
     end
 
   private
@@ -42,16 +42,15 @@ module Yt
       end
     end
 
-    def email_params
-      {}.tap do |params|
-        params[:path] = '/oauth2/v2/userinfo'
-        params[:headers] = {Authorization: "Bearer #{tokens['access_token']}"}
-      end
-    end
-
     # @return [Hash] the tokens of an authenticated Google account.
     def tokens
       HTTPRequest.new(tokens_params).run.body
+    end
+
+    # @return [Hash] the profile of an authenticated Google account.
+    def profile
+      decoded_tokens = JWT.decode tokens['id_token'], nil, false
+      decoded_tokens[0]
     end
 
     def tokens_params

--- a/lib/yt/auth/version.rb
+++ b/lib/yt/auth/version.rb
@@ -1,6 +1,6 @@
 module Yt
   class Auth
     # current version of gem
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/spec/email_spec.rb
+++ b/spec/email_spec.rb
@@ -30,10 +30,8 @@ describe 'Yt::Auth#email' do
     # NOTE: This test needs to be mocked because getting a real authorization
     # code requires a web interaction from a real user.
     before do
-      expect(auth).to receive(:tokens).and_return 'access_token' => '1234'
-      response = double 'response'
-      expect_any_instance_of(Yt::HTTPRequest).to receive(:run) { response }
-      expect(response).to receive(:body).and_return 'email' => email
+      expect(auth).to receive(:tokens).and_return 'id_token' => '1234'
+      expect(JWT).to receive(:decode).and_return [{'email' => email}]
     end
   end
 end

--- a/yt-auth.gemspec
+++ b/yt-auth.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'yt-support', '>= 0.1.1'
+  spec.add_dependency 'jwt', '>= 1.5.6'
 
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rspec', '~> 3.5'


### PR DESCRIPTION
As discussed, we don't need another request after the response from Google with access_token, because access_token comes with JWT encoded id_token, and it already has account email in it.